### PR TITLE
Output tags for include directive

### DIFF
--- a/lib/markedpp.js
+++ b/lib/markedpp.js
@@ -286,6 +286,8 @@ else {
 			lexed = {},
 			_options = merge({}, options);
 
+        _options.tags = false;
+
 		// ppInclude is used to detect recursions
 		if (! _options.ppInclude ) { _options.ppInclude = {}; }
 
@@ -305,7 +307,9 @@ else {
 						return done();
 					}
 					var lexer = new Lexer(_options);
-					src = token.indent + src.split('\n').join('\n' + token.indent);
+                    var sep = '\n' + token.indent;
+					src = token.indent + src.split('\n').join(sep);
+                    if (src.substr(0 - sep.length) === sep) src = src.substr(0, src.length - sep.length + 1);
 					ppInclude( lexer.lex(src), _options, function (err, ntokens){
 						if (err) {
 							// TODO
@@ -332,14 +336,17 @@ else {
 						type: 'ppinclude_start',
 						text: token.text,
 						indent: token.indent,
-						lang: token.lang
+						lang: token.lang,
+                        tags: options.tags
 					});
 					lexed[token.text].forEach(function(token){
 						_tokens.push(merge({},token)); // clone tokens!
 					});
 					_tokens.push({
 						type: 'ppinclude_end',
-						lang: token.lang
+						indent: token.indent,
+						lang: token.lang,
+                        tags: options.tags
 					});
 				}
 				else {
@@ -579,7 +586,7 @@ Lexer.prototype.token = function(src, top) {
 			this.tokens.push({
 				type: 'ppinclude',
 				text: tmp,
-				indent: cap[1],
+				indent: opts.indent ? ' '.repeat(opts.indent) : cap[1],
 				lang: opts.lang
 			});
 			continue;
@@ -1975,16 +1982,26 @@ Parser.prototype.tok = function(options) {
 		}
 		case 'ppinclude_start': {
 			body = '';
+            if (this.token.tags) {
+                var indent = this.token.indent.replace('\t', '    ').length;
+                body += '<!-- include (' + this.token.text.replace(/ /g, '\\ ') +
+                            (this.token.lang ? ' lang=' + this.token.lang : '') +
+                            (indent ? ' indent=' + indent.toString() : '') +
+                        ') -->\n';
+            }
 			if (typeof this.token.lang === 'string') {
-				body = this.renderer.fence(this.token.lang);
+				body += this.renderer.fence(this.token.lang);
 			}
 			return body;
 		}
 		case 'ppinclude_end': {
 			body = '';
 			if (typeof this.token.lang === 'string') {
-				body = this.renderer.fence();
+				body += this.renderer.fence();
 			}
+            if (this.token.tags) {
+                body += '<!-- /include -->\n';
+            }
 			return body;
 		}
 		case 'ppinclude': {

--- a/lib/ppinclude.js
+++ b/lib/ppinclude.js
@@ -36,6 +36,8 @@ function ppIncludeWrap (Lexer, merge) {
 			lexed = {},
 			_options = merge({}, options);
 
+        _options.tags = false;
+
 		// ppInclude is used to detect recursions
 		if (! _options.ppInclude ) { _options.ppInclude = {}; }
 
@@ -53,7 +55,9 @@ function ppIncludeWrap (Lexer, merge) {
 						return done();
 					}
 					var lexer = new Lexer(_options);
-					src = token.indent + src.split('\n').join('\n' + token.indent);
+                    var sep = '\n' + token.indent;
+					src = token.indent + src.split('\n').join(sep);
+                    if (src.substr(0 - sep.length) === sep) src = src.substr(0, src.length - sep.length + 1);
 					ppInclude( lexer.lex(src), _options, function (err, ntokens){
 						lexed[token.text] = ntokens;
 						done();
@@ -77,14 +81,17 @@ function ppIncludeWrap (Lexer, merge) {
 						type: 'ppinclude_start',
 						text: token.text,
 						indent: token.indent,
-						lang: token.lang
+						lang: token.lang,
+                        tags: options.tags
 					});
 					lexed[token.text].forEach(function(token){
 						_tokens.push(merge({},token)); // clone tokens!
 					});
 					_tokens.push({
 						type: 'ppinclude_end',
-						lang: token.lang
+						indent: token.indent,
+						lang: token.lang,
+                        tags: options.tags
 					});
 				}
 				else {

--- a/test/assets/all.exp.md
+++ b/test/assets/all.exp.md
@@ -21,6 +21,7 @@
 
 ## 1.2\. Chapter 1
 
+<!-- include (test\ with\ spaces.js lang=javascript) -->
 ```javascript
 "use strict";
 
@@ -29,17 +30,21 @@
   console.log(str);
 })();
 ```
+<!-- /include -->
 
 [markedpp]: https://github.com/commenthol/markedpp
 
 ## 1.3\. Chapter 2
 
+<!-- include (include2.md indent=4) -->
     Try to recursively load "include2.md".
     
     !include (include2.md)
-    
+<!-- /include -->
+
 [amnesty]: http://www.amnesty.org/ "Amnesty International Homepage"
 
+<!-- include (second/include.md) -->
 ## 1.4\. Include in folder second
 
 Located in folder "second"
@@ -61,6 +66,7 @@ Test third...
 ### 1.6.1\. second
 
 ... second ...
+<!-- /include -->
 
 # 2\. References
 

--- a/test/assets/compatibility.exp.md
+++ b/test/assets/compatibility.exp.md
@@ -32,6 +32,7 @@
 
 ## Include
 
+<!-- include (include1.md) -->
 # Lorem
 
 ## Lorem ipsum
@@ -53,6 +54,7 @@ Nam tincidunt congue enim, ut porta lorem lacinia consectetur. Donec ut libero s
 #### Mauris vitae nisi at
 
 In rutrum accumsan ultricies. Mauris vitae nisi at sem facilisis semper ac in est.
+<!-- /include -->
 
 ## References
 

--- a/test/assets/include.exp.md
+++ b/test/assets/include.exp.md
@@ -2,6 +2,7 @@
 
 Include file from same directory
 
+<!-- include (include1.md) -->
 # Lorem
 
 ## Lorem ipsum
@@ -23,17 +24,21 @@ Nam tincidunt congue enim, ut porta lorem lacinia consectetur. Donec ut libero s
 #### Mauris vitae nisi at
 
 In rutrum accumsan ultricies. Mauris vitae nisi at sem facilisis semper ac in est.
+<!-- /include -->
 
 # Include recursively
 
+<!-- include (include2.md) -->
 Try to recursively load "include2.md".
 
 !include (include2.md)
+<!-- /include -->
 
 # Include a source file
 
 Put the file in GFM Fences
 
+<!-- include (test\ with\ spaces.js lang=javascript) -->
 ```javascript
 "use strict";
 
@@ -42,22 +47,27 @@ Put the file in GFM Fences
   console.log(str);
 })();
 ```
+<!-- /include -->
 
 ## Include with indent
 
+<!-- include (test.js indent=4) -->
     "use strict";
     
     (function(){
       var str = "this is a string";
       console.log(str);
     })();
-    
+<!-- /include -->
+
 ### Include with indents on indents
 
 * Level 1 Indent
+  <!-- include (indent.md) -->
   * Level 2 Indent
     * Level 3 Indent
       * Level 4 Indent
+  <!-- /include -->
 
 # Include a not existing file
 
@@ -65,6 +75,7 @@ Put the file in GFM Fences
 
 # Include from a differerent folder
 
+<!-- include (second/include.md) -->
 ## Include in folder second
 
 Located in folder "second"
@@ -86,6 +97,7 @@ Test third...
 ### second
 
 ... second ...
+<!-- /include -->
 
 ## Ignore within GFM fences
 

--- a/test/assets/index.html
+++ b/test/assets/index.html
@@ -82,6 +82,7 @@
 
 ## 1.2\. Chapter 1
 
+<!-- include (test\ with\ spaces.js lang=javascript) -->
 ```javascript
 "use strict";
 
@@ -90,17 +91,21 @@
   console.log(str);
 })();
 ```
+<!-- /include -->
 
 [markedpp]: https://github.com/commenthol/markedpp
 
 ## 1.3\. Chapter 2
 
+<!-- include (include2.md indent=4) -->
     Try to recursively load "include2.md".
     
     !include (include2.md)
-    
+<!-- /include -->
+
 [amnesty]: http://www.amnesty.org/ "Amnesty International Homepage"
 
+<!-- include (second/include.md) -->
 ## 1.4\. Include in folder second
 
 Located in folder "second"
@@ -122,6 +127,7 @@ Test third...
 ### 1.6.1\. second
 
 ... second ...
+<!-- /include -->
 
 # 2\. References
 

--- a/test/markedpp.mocha.js
+++ b/test/markedpp.mocha.js
@@ -31,7 +31,14 @@ var	u = {
 		markedpp(src, opt, function (err, res) {
 			//~ console.log(res);
 			assert.equal(res, exp);
-			done();
+            if (opt.tags === false) {
+                return done();
+            }
+			
+            markedpp(exp, opt, function (err, res) {
+                assert.equal(res, exp);
+                done();
+            });
 		});
 	}
 };


### PR DESCRIPTION
Add support for pre-proc tags for the include directive.

Only the top level include directive will output surrounding tags, no tags will be outputted for directives inside the included file.

This allows for outputting stable files, which can be re-processed and output the same content.
