### PR TITLE
Output anchor name tags in valid html syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Add numbers on headings
 
 All Headings up to level 3 will get numbered. If used, this command shall be given at the very top of a document.
 
-<a name="numberedheadings-level"/>
+<a name="numberedheadings-level"></a>
 #### level
 
 With the option `level`, the Headings level where the numbering shall be applied, can be specified.
@@ -242,22 +242,22 @@ E.g.
 1\. [One](#1-one) <br>
 1.1\. [One One](#1-1-one-one)
 
-<a name="numberedheadings-minlevel"/>
+<a name="numberedheadings-minlevel"></a>
 #### minlevel
 
 The option `minlevel` omits numbering all Headings below `minlevel`.
 
-<a name="numberedheadings-skip"/>
+<a name="numberedheadings-skip"></a>
 #### skip
 
 The option `skip` skips numbering for the first Headings on `minlevel`.
 
-<a name="numberedheadings-start"/>
+<a name="numberedheadings-start"></a>
 #### start
 
 The option `start` starts the numbering with the given number.
 
-<a name="numberedheadings-omit"/>
+<a name="numberedheadings-omit"></a>
 #### omit
 
 The option `omit` omits numbering all Headings matching.
@@ -266,10 +266,10 @@ The option `omit` omits numbering all Headings matching.
 
 ### Using custom anchors
 
-Custom anchors can be added to headings by putting a `<a name="..."/>` in a separate line right in front of the heading.
+Custom anchors can be added to headings by putting a `<a name="..."></a>` in a separate line right in front of the heading.
 
 ```html
-<a name="custom-heading"/>
+<a name="custom-heading"></a>
 # Heading with custom id
 ```
 

--- a/lib/markedpp.js
+++ b/lib/markedpp.js
@@ -1267,7 +1267,7 @@ function Renderer(options) {
 Renderer.prototype.heading = function(text, level, raw, number, autoid, anchor) {
 	var atx = '';
 	if (anchor) {
-		atx += '<a name="'+anchor+'"/>\n';
+		atx += '<a name="'+anchor+'"></a>\n';
 	}
 	atx += '########'.substring(0, level);
 	return atx + ' ' + text + '\n';

--- a/test/assets/toc_id.exp.md
+++ b/test/assets/toc_id.exp.md
@@ -8,16 +8,16 @@
 
 <!-- toc! -->
 
-<a name="anchor-headingid1"/>
+<a name="anchor-headingid1"></a>
 # Heading 1
 
 ## Heading 1.1
 
-<a name="anchor-headingid2"/>
+<a name="anchor-headingid2"></a>
 # Heading 2
 
-<a name="anchor-headingid3"/>
+<a name="anchor-headingid3"></a>
 # Heading 3
 
-<a name="anchor-headingid4"/>
+<a name="anchor-headingid4"></a>
 ## Heading 4


### PR DESCRIPTION
`<a name="custom-heading"/>` is not valid html since self closing tags are not allowed. Furthermore it's actually discouraged XHTML per the [compatibility guideline 3](https://www.w3.org/TR/xhtml-media-types/#C_3).

Anchor tag is a non-void html element. A self closing anchor tag are often considered by parsers as a start tag, which means subsequent elements become children of the anchor. See this [Stack Overflow answer](http://stackoverflow.com/a/3558200) for a good summary of why.
