### PR TITLE
Add option to skip escaping of last `.` in headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ Files to insert which cannot be found or recursive inset of the same file leaves
 
 ### 1.4\. numberedheadings
 
-    !numberedheadings [([level=1-6] [minlevel=1-6] [skip=1..] [start=1..] [omit="...;..."])]
+    !numberedheadings [([level=1-6] [minlevel=1-6] [skip=1..] [start=1..] [omit="...;..."] [skipEscaping])]
 
 Add numbers on headings
 
@@ -241,6 +241,7 @@ Add numbers on headings
 * skip: {Number} \[optional\] skip number of Headings on min-level
 * start: {Number} \[optional\] start numbering of Headings with given number
 * omit: {String} \[optional\] omit numbering of Headings. Headings need to be given in `"` and separated by `;`
+* skipEscaping: \[optional\] if enabled `\` will not escape the last `.` in Headings
 
 All Headings up to level 3 will get numbered. If used, this command shall be given at the very top of a document.
 

--- a/src/Lexer.js
+++ b/src/Lexer.js
@@ -278,7 +278,8 @@ Lexer.prototype.token = function (src, top) {
         minlevel: Lexer.range(opts.minlevel, defaults.minlevel, 6),
         skip: opts.skip,
         start: opts.start,
-        omit: opts.omit
+        omit: opts.omit,
+        skipEscaping: opts.skipEscaping
       })
       continue
     }

--- a/src/Numbering.js
+++ b/src/Numbering.js
@@ -3,10 +3,11 @@
  * @constructor
  * @api private
  */
-function Numbering (init) {
+function Numbering(init, skipEscaping) {
   this._ = [0, 0, 0, 0, 0, 0, 0]
   this.last = 1
   this._[1] = (init ? init - 1 : 0)
+  this.skipEscaping = skipEscaping
 }
 
 /**
@@ -30,7 +31,7 @@ Numbering.prototype.val = function (level) {
   for (let i = 2; i <= level; i++) {
     out += '.' + this._[i]
   }
-  return out + '\\.'
+  return out + (this.skipEscaping ? '.' : '\\.')
 }
 
 /**

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -225,10 +225,10 @@ Parser.prototype.updateAutoIdentifier = function () {
  * @param {Number} maxLevel
  * @param {Number} minLevel
  */
-Parser.prototype.numberedHeadings = function (maxLevel, minLevel, skip, start, omit) {
+Parser.prototype.numberedHeadings = function (maxLevel, minLevel, skip, start, omit, skipEscaping) {
   const omitMatch = {}
   let skipFlag = false
-  const numbering = new Numbering(start)
+  const numbering = new Numbering(start, skipEscaping)
 
   skip = skip || 0
 
@@ -397,7 +397,8 @@ Parser.prototype.tok = function (options) {
         this.token.minlevel,
         this.token.skip,
         this.token.start,
-        this.token.omit
+        this.token.omit,
+        this.token.skipEscaping
       )
       this.updateAutoIdentifier()
       return this.renderer.numberedHeadings(
@@ -405,7 +406,8 @@ Parser.prototype.tok = function (options) {
         this.token.minlevel,
         this.token.skip,
         this.token.start,
-        this.token.omit
+        this.token.omit,
+        this.token.skipEscaping
       )
     }
     case 'ppref':

--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -326,13 +326,14 @@ Renderer.prototype.tableOfContents = function (toc, options) {
  * @param {Number} minLevel
  * @return {String} rendered output
  */
-Renderer.prototype.numberedHeadings = function (maxLevel, minLevel, skip, start, omit) {
+Renderer.prototype.numberedHeadings = function (maxLevel, minLevel, skip, start, omit, skipEscaping) {
   const opts = this.joinOpts({
     level: maxLevel,
     minlevel: minLevel,
     skip,
     start,
-    omit
+    omit,
+    skipEscaping
   })
   if (this.options.tags) {
     return '<!-- !numberedheadings ' + opts + '-->\n\n'

--- a/test/assets/numberedheadings_skipEscaping.exp.md
+++ b/test/assets/numberedheadings_skipEscaping.exp.md
@@ -1,0 +1,65 @@
+<!-- !numberedheadings (skipEscaping) -->
+
+# 1. Table of Contents
+
+<!-- !toc (level=4) -->
+
+* [1. Table of Contents](#1-table-of-contents)
+* [2. One](#2-one)
+  * [2.1. One One](#21-one-one)
+    * [2.1.1. One One One](#211-one-one-one)
+      * [One One One One](#one-one-one-one)
+* [3. Two](#3-two)
+  * [3.1. Two One](#31-two-one)
+      * [Two One One One](#two-one-one-one)
+      * [Two One One Two](#two-one-one-two)
+  * [3.2. Two Three](#32-two-three)
+  * [3.3. Two Four](#33-two-four)
+    * [3.3.1. Two Four One](#331-two-four-one)
+      * [Two Four One One](#two-four-one-one)
+      * [Two Four One Two](#two-four-one-two)
+      * [Two Four One Three](#two-four-one-three)
+      * [Two Four One Four](#two-four-one-four)
+* [4. Three](#4-three)
+
+<!-- toc! -->
+
+----
+
+# 2. One
+
+## 2.1. One One
+
+### 2.1.1. One One One
+
+#### One One One One
+
+##### One One One One One
+
+###### One One One One One One
+
+# 3. Two
+
+## 3.1. Two One
+
+#### Two One One One
+
+#### Two One One Two
+
+## 3.2. Two Three
+
+## 3.3. Two Four
+
+### 3.3.1. Two Four One
+
+#### Two Four One One
+
+#### Two Four One Two
+
+#### Two Four One Three
+
+#### Two Four One Four
+
+# 4. Three
+
+

--- a/test/assets/numberedheadings_skipEscaping.md
+++ b/test/assets/numberedheadings_skipEscaping.md
@@ -1,0 +1,45 @@
+!numberedheadings (skipEscaping)
+
+# Table of Contents
+
+!toc (level=4)
+
+----
+
+# 1. One
+
+## 1.7. One One
+
+### 2.2.2. One One One
+
+#### One One One One
+
+##### One One One One One
+
+###### One One One One One One
+
+# Two
+
+## Two One
+
+#### Two One One One
+
+#### Two One One Two
+
+## Two Three
+
+## Two Four
+
+### Two Four One
+
+#### Two Four One One
+
+#### Two Four One Two
+
+#### Two Four One Three
+
+#### Two Four One Four
+
+# Three
+
+

--- a/test/markedpp.spec.js
+++ b/test/markedpp.spec.js
@@ -161,6 +161,10 @@ describe('numberedheadings', function () {
     u.run('numberedheadings.md', done)
   })
 
+  it('numberedheadings skipEscaping', function (done) {
+    u.run('numberedheadings_skipEscaping.md', done)
+  })
+
   it('numberedheadings level=2', function (done) {
     u.run('numberedheadings_level2.md', done)
   })


### PR DESCRIPTION
Currently headings will always print as such: `### 1.2.3\. Heading`, with a backslash escaping the last `.`. This PR adds option to skip backslash. You can use it like this `!numberedheadings (skipEscaping)`.