### PR TITLE
Add options to include portions of files

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,15 +206,24 @@ renders as:
 
 ### 1.3\. include
 
-    !include (filename [lang=...])
+    !include (filename [lang=...] [indent=x] [start=x] [end=x] [link="label"] [vscode="label"])
 
 This inserts the the file specified with `filename` at the given position in the document being preprocessed.
 The preprocessor inserts any type of files.
 
 * filename: \[mandatory\] Name of file to include
 * lang: \[optional\] language of file - if set, then [GFM][GFM] fences are added around include.
+* indent: \[optional\] Indent the included file by `x` spaces
+* start: \[optional\] Start including the file from line `x`
+* end: \[optional\] End including the file at line `x`
+* link: \[optional\] Add a link to this include file with the given label
+* vscode: \[optional\] Add a vscode link to this include file with the given label for vscode
 
 To include a file with specifying the language use the option `lang`.
+
+`start` and `end` will include only the lines from `start` to `end` from the source file.  If only `start` is specified, the lines beginning at `start` will be included to the end of the file.  If only `end` is specified, the lines from the beginning of the file to `end` will be included.
+
+The `link` and `vscode` options will add a link in the resulting file that will allow you to open the original file. The text specified in `label` will be the name of the link in the markdown file.  This is useful for including code snippets within the markdown file and still allow navigation to the original source file.
 
 This then will render using [GFM][GFM] fences.
 

--- a/src/Lexer.js
+++ b/src/Lexer.js
@@ -88,12 +88,20 @@ Lexer.prototype.token = function (src, top) {
       src = src.substring(cap[0].length)
       tmp = cap[2] || cap[3] || cap[4]
       opts = Lexer.splitOpts(tmp)
-      tmp = tmp.replace(/ *(?:[a-z]+=[a-z0-9-]+)/, '').replace(/\\ /g, ' ')
+
+      // remove all possible attributes: lang, indent, start, end, link, vscode
+      tmp = tmp.replaceAll(/ *(?:[a-z]+="[a-zA-Z0-9- ]+")/g, '').replace(/\\ /g, ' ')
+      tmp = tmp.replaceAll(/ *(?:[a-z]+=[a-z0-9-]+)/g, '').replace(/\\ /g, ' ')
+
       this.tokens.push({
         type: 'ppinclude',
         text: tmp,
         indent: opts.indent ? repeat(' ', opts.indent) : cap[1],
-        lang: opts.lang
+        lang: opts.lang,
+        start: opts.start,
+        end: opts.end,
+        link: opts.link,
+        vscode: opts.vscode
       })
       continue
     }

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -1,3 +1,4 @@
+const path = require('path')
 const InlineLexer = require('./InlineLexer')
 const Renderer = require('./Renderer')
 const Numbering = require('./Numbering')
@@ -422,6 +423,8 @@ Parser.prototype.tok = function (options) {
         body += '<!-- include (' + this.token.text.replace(/ /g, '\\ ') +
             (this.token.lang ? ' lang=' + this.token.lang : '') +
             (indent ? ' indent=' + indent.toString() : '') +
+            (this.token.start ? ' start=' + this.token.start : '') +
+            (this.token.end ? ' end=' + this.token.end : '') +
             ') -->\n'
       }
       if (typeof this.token.lang === 'string') {
@@ -437,6 +440,17 @@ Parser.prototype.tok = function (options) {
       }
       if (this.token.tags) {
         body += '<!-- /include -->\n'
+      }
+      if (this.token.link) {
+        body += this.renderer.link(this.token.raw, this.token.link, this.token.text) + '\n'
+      }
+      if (this.token.vscode) {
+        const dirname = this.token.dirname || process.cwd()
+        const file = path.resolve(path.join(dirname, this.token.text))
+
+        /* vscode url format is an absolute path with a file:// scheme */
+        const uri = 'vscode://file/' + file + (this.token.start ? ':' + this.token.start + ':1' : '')
+        body += this.renderer.link(this.token.raw, this.token.vscode, uri) + '\n'
       }
       return body
     }

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -1,4 +1,3 @@
-const path = require('path')
 const InlineLexer = require('./InlineLexer')
 const Renderer = require('./Renderer')
 const Numbering = require('./Numbering')
@@ -444,12 +443,9 @@ Parser.prototype.tok = function (options) {
       if (this.token.link) {
         body += this.renderer.link(this.token.raw, this.token.link, this.token.text) + '\n'
       }
-      if (this.token.vscode) {
-        const dirname = this.token.dirname || process.cwd()
-        const file = path.resolve(path.join(dirname, this.token.text))
-
+      if (this.token.vscode && this.token.vscodefile) {
         /* vscode url format is an absolute path with a file:// scheme */
-        const uri = 'vscode://file/' + file + (this.token.start ? ':' + this.token.start + ':1' : '')
+        const uri = 'vscode://file/' + this.token.vscodefile + (this.token.start ? ':' + this.token.start + ':1' : '')
         body += this.renderer.link(this.token.raw, this.token.vscode, uri) + '\n'
       }
       return body

--- a/src/ppInclude-browser.js
+++ b/src/ppInclude-browser.js
@@ -259,6 +259,8 @@ function ppInclude (tokens, Lexer, options, callback) {
     // compose the new tokens array
     tokens.forEach(function (token) {
       const text = getUniqueFileName(token)
+      const dirname = options.dirname || ''
+      const vscodefile = token.vscode ? path.resolve(path.join(dirname, token.text)) : undefined
 
       if (token.type === 'ppinclude' &&
           typeof token.text === 'string' &&
@@ -272,6 +274,7 @@ function ppInclude (tokens, Lexer, options, callback) {
           end: token.end,
           link: token.link,
           vscode: token.vscode,
+          vscodefile,
           dirname: options.dirname,
           tags: options.tags
         })
@@ -287,6 +290,7 @@ function ppInclude (tokens, Lexer, options, callback) {
           end: token.end,
           link: token.link,
           vscode: token.vscode,
+          vscodefile,
           dirname: options.dirname,
           tags: options.tags
         })

--- a/src/ppInclude.js
+++ b/src/ppInclude.js
@@ -98,6 +98,8 @@ function ppInclude (tokens, Lexer, options, callback) {
     // compose the new tokens array
     tokens.forEach(function (token) {
       const text = getUniqueFileName(token)
+      const dirname = options.dirname || process.cwd()
+      const vscodefile = token.vscode ? path.resolve(path.join(dirname, token.text)) : undefined
 
       if (token.type === 'ppinclude' &&
           typeof token.text === 'string' &&
@@ -111,6 +113,7 @@ function ppInclude (tokens, Lexer, options, callback) {
           end: token.end,
           link: token.link,
           vscode: token.vscode,
+          vscodefile,
           dirname: options.dirname,
           tags: options.tags
         })
@@ -126,6 +129,7 @@ function ppInclude (tokens, Lexer, options, callback) {
           end: token.end,
           link: token.link,
           vscode: token.vscode,
+          vscodefile,
           dirname: options.dirname,
           tags: options.tags
         })

--- a/src/ppInclude.js
+++ b/src/ppInclude.js
@@ -16,6 +16,24 @@ const fs = require('fs')
 const path = require('path')
 const async = require('asyncc')
 
+/* generate a unique key for partial include file names that incorporates the start/end values */
+function getUniqueFileName (token) {
+  return token.text + '(start=' + (token.start || '') + 'end=' + (token.end || '') + ')'
+}
+
+function partialInclude (src, start, end) {
+  if (Number.isInteger(start) || Number.isInteger(end)) {
+    const srcLines = src.split('\n')
+    const firstLine = Number.isInteger(start) && start > 0 ? start - 1 : 0
+    const lastLine = Number.isInteger(end) && end > 0 ? end : srcLines.length
+
+    return srcLines.slice(firstLine, lastLine).join('\n') + '\n'
+  } else {
+    // no start/end specified, return the original src
+    return src
+  }
+}
+
 /**
  * Include and Lex files
  * @param {Array} tokens - array of tokens
@@ -35,19 +53,25 @@ function ppInclude (tokens, Lexer, options, callback) {
   }
 
   async.eachLimit(5, tokens, function (token, done) {
+    const text = getUniqueFileName(token)
     if (token.type === 'ppinclude' &&
       typeof token.text === 'string' &&
-      !_options.ppInclude[token.text]
+      !_options.ppInclude[text]
     ) {
       const file = path.resolve(path.join(dirname, token.text))
+      // eslint-disable-next-line no-console
+      // console.error('readFile dirname', dirname, 'options.dirname', options.dirname, 'token.text', token.text, 'file', file)
       fs.readFile(file, 'utf8', function (err, src) {
-        _options.ppInclude[token.text] = 1
+        _options.ppInclude[text] = 1
         _options.dirname = path.dirname(file)
         if (err) {
           // eslint-disable-next-line no-console
           console.error('Error: ' + err.message)
           return done()
         }
+
+        src = partialInclude(src, token.start, token.end)
+
         const lexer = new Lexer(_options)
         const sep = '\n' + token.indent
         src = token.indent + src.split('\n').join(sep)
@@ -59,7 +83,8 @@ function ppInclude (tokens, Lexer, options, callback) {
             // eslint-disable-next-line no-console
             console.error('Error: ' + err.message)
           }
-          lexed[token.text] = ntokens
+          // make token.text unique if include details differ
+          lexed[text] = ntokens
           done()
         })
       })
@@ -72,23 +97,36 @@ function ppInclude (tokens, Lexer, options, callback) {
 
     // compose the new tokens array
     tokens.forEach(function (token) {
+      const text = getUniqueFileName(token)
+
       if (token.type === 'ppinclude' &&
           typeof token.text === 'string' &&
-          lexed[token.text] !== undefined) {
+          lexed[text] !== undefined) {
         _tokens.push({
           type: 'ppinclude_start',
           text: token.text,
           indent: token.indent,
           lang: token.lang,
+          start: token.start,
+          end: token.end,
+          link: token.link,
+          vscode: token.vscode,
+          dirname: options.dirname,
           tags: options.tags
         })
-        lexed[token.text].forEach(function (token) {
+        lexed[text].forEach(function (token) {
           _tokens.push(Object.assign({}, token)) // clone tokens!
         })
         _tokens.push({
           type: 'ppinclude_end',
+          text: token.text,
           indent: token.indent,
           lang: token.lang,
+          start: token.start,
+          end: token.end,
+          link: token.link,
+          vscode: token.vscode,
+          dirname: options.dirname,
           tags: options.tags
         })
       } else {

--- a/test/assets/include.exp.md
+++ b/test/assets/include.exp.md
@@ -106,3 +106,28 @@ Test third...
 
 # heading
 ```
+
+# Include a portion of a file
+
+<!-- include (include1.md start=3 end=9) -->
+## Lorem ipsum
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+
+### Donec a diam
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<!-- /include -->
+
+## Include a portion of a file with a link
+
+<!-- include (include1.md start=3 end=9) -->
+## Lorem ipsum
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+
+### Donec a diam
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<!-- /include -->
+[Click to Open](include1.md)

--- a/test/assets/include.md
+++ b/test/assets/include.md
@@ -38,3 +38,19 @@ Put the file in GFM Fences
 
 # heading
 ```
+
+# Include a portion of a file
+
+!include (include1.md start=3 end=9) 
+
+## Include a portion of a file with a link
+
+!include (include1.md start=3 end=9 link="Click to Open") 
+
+## Include a portion of a file with a vscode link
+
+!include (include1.md start=3 end=9 vscode="Open in VSCode") 
+
+## Include a portion of a file with a link and a vscode link
+
+!include (include1.md start=3 end=9 link="Click to Open" vscode="Open in VSCode")  

--- a/test/assets/include.md
+++ b/test/assets/include.md
@@ -46,11 +46,3 @@ Put the file in GFM Fences
 ## Include a portion of a file with a link
 
 !include (include1.md start=3 end=9 link="Click to Open") 
-
-## Include a portion of a file with a vscode link
-
-!include (include1.md start=3 end=9 vscode="Open in VSCode") 
-
-## Include a portion of a file with a link and a vscode link
-
-!include (include1.md start=3 end=9 link="Click to Open" vscode="Open in VSCode")  

--- a/test/markedpp.spec.js
+++ b/test/markedpp.spec.js
@@ -208,7 +208,7 @@ describe('numberedheadings', function () {
 
 describe('include', function () {
   it('read include.md and compare', function (done) {
-    u.run('include.md', {}, done)
+    u.run('include.md', done, {})
   })
 })
 


### PR DESCRIPTION
I use markdown for the lecture portion of a class I teach.  There are lots of embedded code examples. The samples are usually part of a larger code module, so it's convenient to be able to just include a few lines of the source in the markdown.  I also often jump between the markdown lecture material and the actual code, so having a hyperlink to the complete source file is also useful.  This PR adds options to the existing include to allow specifying a start and end line for including a subsection of the file. It also adds a `link` and `vscode` option. `link` will just provide a hyperlink to the original include file.  `vscode` will include a link that will open Visual Studio Code with the given file and starting line.