### PR TITLE
fix `--version` command option for CLI since ESM migration

### DIFF
--- a/bin/markedpp.js
+++ b/bin/markedpp.js
@@ -17,6 +17,8 @@ import { fileURLToPath } from 'node:url'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
+const packageJson = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../package.json'), 'utf8'))
+const packageVersion = packageJson.version
 
 /**
  * Helpers
@@ -185,7 +187,7 @@ main(process.argv.slice(), function (err, code) {
 
 function version () {
   // eslint-disable-next-line no-console
-  console.log('v' + require('../package.json').version)
+  console.log('v' + packageVersion)
 }
 
 function help () {


### PR DESCRIPTION
resolves #10 